### PR TITLE
BTX MetaData CSV Import

### DIFF
--- a/src/main/java/net/digimonworld/decodetools/gui/BTXPanel.java
+++ b/src/main/java/net/digimonworld/decodetools/gui/BTXPanel.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.LinkedList;
 import java.util.List;
 
 import javax.swing.GroupLayout;
@@ -18,6 +19,7 @@ import net.digimonworld.decodetools.core.Tuple;
 import net.digimonworld.decodetools.gui.util.FunctionAction;
 import net.digimonworld.decodetools.res.payload.BTXPayload;
 import net.digimonworld.decodetools.res.payload.BTXPayload.BTXEntry;
+import net.digimonworld.decodetools.res.payload.BTXPayload.BTXMeta;
 
 import javax.swing.JScrollPane;
 
@@ -46,8 +48,21 @@ public class BTXPanel extends PayloadPanel {
                     String[] split = b.split(";");
                     int id = Integer.parseInt(split[0]);
                     String string = split[1];
-                    
-                    list.add(new Tuple<>(id, new BTXEntry(string, null)));
+                    int speaker = Integer.parseInt(split[2]);
+                    short unk1=Short.parseShort(split[3]);
+                    byte unk2 = Byte.parseByte(split[4]);
+                    byte unk3 = Byte.parseByte(split[5]);
+                    int unk4 =Integer.parseInt(split[6]);
+                    int unk5 = Integer.parseInt(split[7]);                   
+                    int unk6 =Integer.parseInt(split[8]);
+                    int unk7 = Integer.parseInt(split[9]);
+                    int unk8 = Integer.parseInt(split[10]);
+                    int unk9 = Integer.parseInt(split[11]);
+                    int unk10 = Integer.parseInt(split[12]);
+                    int unk11 = Integer.parseInt(split[13]);
+                    int unk12 = Integer.parseInt(split[14]);
+                    BTXMeta btxmeta = new BTXMeta(id,speaker,unk1,unk2,unk3,unk4,unk5,unk6,unk7,unk8,unk9,unk10,unk11,unk12);
+                    list.add(new Tuple<>(id, new BTXEntry(string, btxmeta)));
                 });
             }
             catch (FileNotFoundException e) {
@@ -95,6 +110,15 @@ public class BTXPanel extends PayloadPanel {
             model.addColumn("Unk1");
             model.addColumn("Unk2");
             model.addColumn("Unk3");
+            model.addColumn("Unk4");  
+            model.addColumn("Unk5");
+            model.addColumn("Unk6");
+            model.addColumn("Unk7");
+            model.addColumn("Unk8");
+            model.addColumn("Unk9");
+            model.addColumn("Unk10");
+            model.addColumn("Unk11");
+            model.addColumn("Unk12");
             
             payload.getEntries().forEach(a -> {
                 int id = a.getKey();
@@ -103,8 +127,16 @@ public class BTXPanel extends PayloadPanel {
                 Short unk1 = a.getValue().getMeta().isPresent() ? a.getValue().getMeta().get().getUnk1() : null;
                 Byte unk2 = a.getValue().getMeta().isPresent() ? a.getValue().getMeta().get().getUnk2() : null;
                 Byte unk3 = a.getValue().getMeta().isPresent() ? a.getValue().getMeta().get().getUnk3() : null;
-                
-                model.addRow(new Object[] { id, string, speaker, unk1, unk2, unk3 });
+                Integer unk4 = a.getValue().getMeta().isPresent() ? a.getValue().getMeta().get().getUnk4() : null;
+                Integer unk5 = a.getValue().getMeta().isPresent() ? a.getValue().getMeta().get().getUnk5() : null;
+                Integer unk6 = a.getValue().getMeta().isPresent() ? a.getValue().getMeta().get().getUnk6() : null;
+                Integer unk7 = a.getValue().getMeta().isPresent() ? a.getValue().getMeta().get().getUnk7() : null;
+                Integer unk8 = a.getValue().getMeta().isPresent() ? a.getValue().getMeta().get().getUnk8() : null;
+                Integer unk9 = a.getValue().getMeta().isPresent() ? a.getValue().getMeta().get().getUnk9() : null;
+                Integer unk10 = a.getValue().getMeta().isPresent() ? a.getValue().getMeta().get().getUnk10() : null;
+                Integer unk11 = a.getValue().getMeta().isPresent() ? a.getValue().getMeta().get().getUnk11() : null;
+                Integer unk12 = a.getValue().getMeta().isPresent() ? a.getValue().getMeta().get().getUnk12() : null;
+                model.addRow(new Object[] { id, string, speaker, unk1, unk2, unk3,unk4,unk5,unk6,unk7,unk8,unk9,unk10,unk11,unk12});
             });
             
             table.setModel(model);

--- a/src/main/java/net/digimonworld/decodetools/res/payload/BTXPayload.java
+++ b/src/main/java/net/digimonworld/decodetools/res/payload/BTXPayload.java
@@ -218,11 +218,11 @@ public class BTXPayload extends ResPayload {
             unknown11 = source.readInteger();
         }
                  
-		public BTXMeta(int btxid, int speakerid, short unk1, byte unk2, byte unk3, int unk4, int unk5, int unk6, int unk7,
+	public BTXMeta(int btxid, int speakerid, short unk1, byte unk2, byte unk3, int unk4, int unk5, int unk6, int unk7,
 				int unk8, int unk9, int unk10, int unk11, int unk12) {
-			id = btxid;
-		  	speaker = speakerid;
-        	unknown2_1 = unk1;
+            id = btxid;
+            speaker = speakerid;
+            unknown2_1 = unk1;
             unknown2_2 = unk2;
             unknown2_3 = unk3;
             unknown3 = unk4;
@@ -234,10 +234,10 @@ public class BTXPayload extends ResPayload {
             unknown9 = unk10;
             unknown10 = unk11;
             unknown11 = unk12;
-		}
+	}
 
 
-		public void writeKCAP(Access dest) {
+	public void writeKCAP(Access dest) {
             dest.writeInteger(id);
             dest.writeInteger(speaker);
             dest.writeShort(unknown2_1);

--- a/src/main/java/net/digimonworld/decodetools/res/payload/BTXPayload.java
+++ b/src/main/java/net/digimonworld/decodetools/res/payload/BTXPayload.java
@@ -194,6 +194,9 @@ public class BTXPayload extends ResPayload {
         private int unknown9;
         private int unknown10;
         private int unknown11;
+        private int unknown12;
+        private int unknown13;
+        private int unknown14;
         
         public BTXMeta(Access source) {
             id = source.readInteger();
@@ -214,8 +217,27 @@ public class BTXPayload extends ResPayload {
             unknown10 = source.readInteger();
             unknown11 = source.readInteger();
         }
-        
-        public void writeKCAP(Access dest) {
+                 
+		public BTXMeta(int btxid, int speakerid, short unk1, byte unk2, byte unk3, int unk4, int unk5, int unk6, int unk7,
+				int unk8, int unk9, int unk10, int unk11, int unk12) {
+			id = btxid;
+		  	speaker = speakerid;
+        	unknown2_1 = unk1;
+            unknown2_2 = unk2;
+            unknown2_3 = unk3;
+            unknown3 = unk4;
+            unknown4 = unk5;
+            unknown5 = unk6;
+            unknown6 = unk7;
+            unknown7 = unk8;         
+            unknown8 = unk9;
+            unknown9 = unk10;
+            unknown10 = unk11;
+            unknown11 = unk12;
+		}
+
+
+		public void writeKCAP(Access dest) {
             dest.writeInteger(id);
             dest.writeInteger(speaker);
             dest.writeShort(unknown2_1);
@@ -268,7 +290,44 @@ public class BTXPayload extends ResPayload {
         public byte  getUnk3() {
             return unknown2_3;
         }
-    }
+        
+        public int  getUnk4() {
+            return unknown3;
+        }
+        
+        public int  getUnk5() {
+            return unknown4;
+        }
+        
+        public int  getUnk6() {
+            return unknown5;
+        }
+        
+        public int  getUnk7() {
+            return unknown6;
+        }
+        
+        public int  getUnk8() {
+            return unknown7;
+        }  
+        
+        public int  getUnk9() {
+            return unknown8;
+        }
+        
+        public int  getUnk10() {
+            return unknown9;
+        }
+        
+        public int  getUnk11() {
+            return unknown10;
+        }
+        
+        public int  getUnk12() {
+            return unknown11;
+        }
+
+        }
     
     /**
      * An entry to a BTX, containing a String and an optional {@link BTXMeta}.


### PR DESCRIPTION
Adds basic MetaData Import when Data is present in CSV, otherwise null.
Panel extended to show the new columns, getters for the variables, new constructor for the CSV Import.