### PR TITLE
Fix joint import/export for bones with rotations and scales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@
 .classpath
 .project
 /Cs_Models_Rigged/
+
+# IntelliJ Workspace
+.idea/*
+
+# Maven
+*.iml

--- a/src/main/java/net/digimonworld/decodetools/gui/ColldadaExporter.java
+++ b/src/main/java/net/digimonworld/decodetools/gui/ColldadaExporter.java
@@ -25,6 +25,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import net.digimonworld.decodetools.Main;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -46,10 +47,211 @@ import net.digimonworld.decodetools.res.payload.xtvo.XTVORegisterType;
 import net.digimonworld.decodetools.res.payload.xtvo.XTVOVertex;
 
 public class ColldadaExporter {
-    
+
     private final Document doc;
     private final HSMPKCAP hsmp;
-    
+
+    ////////////////////////////
+    // BEGIN LINALG FUNCTIONS //
+    ////////////////////////////
+    private float[] quaternionToMatrix3x3(float[] quat) {
+        float[] out = new float[9];
+
+        float xSq = 2*quat[0]*quat[0];
+        float ySq = 2*quat[1]*quat[1];
+        float zSq = 2*quat[2]*quat[2];
+
+        float xy = 2*quat[0]*quat[1];
+        float xz = 2*quat[0]*quat[2];
+        float xw = 2*quat[0]*quat[3];
+
+        float yz = 2*quat[1]*quat[2];
+        float yw = 2*quat[1]*quat[3];
+
+        float zw = 2*quat[2]*quat[3];
+
+        // Create rotation matrix
+        out[0] = 1 - ySq - zSq;
+        out[1] = xy - zw;
+        out[2] = xz + yw;
+
+        out[3] = xy + zw;
+        out[4] = 1 - xSq - zSq;
+        out[5] = yz - xw;
+
+        out[6] = xz - yw;
+        out[7] = yz + xw;
+        out[8] = 1 - xSq - ySq;
+
+
+        return out;
+    }
+
+    private float[] makeTransformMatrix(float[] pos, float[] quat, float[] scale) {
+        // Make quat matrix
+        float[] rot_matrix = quaternionToMatrix3x3(quat);
+
+        float[] out = new float[16];
+        // Inner product of (rotation . scale) - scale is a diagonal matrix
+        out[0] = rot_matrix[0] * scale[0];
+        out[4] = rot_matrix[3] * scale[0];
+        out[8] = rot_matrix[6] * scale[0];
+
+        out[1] = rot_matrix[1] * scale[1];
+        out[5] = rot_matrix[4] * scale[1];
+        out[9] = rot_matrix[7] * scale[1];
+
+        out[2] = rot_matrix[2] * scale[2];
+        out[6] = rot_matrix[5] * scale[2];
+        out[10] = rot_matrix[8] * scale[2];
+
+        // Inner product of (translation . rotscale) - translation is a Frobenius matrix
+        out[3] = pos[0];
+        out[7] = pos[1];
+        out[11] = pos[2];
+
+        // Add affine coordinate
+        out[15] = 1;
+
+        return out;
+    }
+
+    private float[] crossProduct(float[] vec_1, float[] vec_2) {
+        float[] out = new float[3];
+        out[0] = vec_1[1] * vec_2[2] - vec_1[2] * vec_2[1];
+        out[1] = vec_1[2] * vec_2[0] - vec_1[0] * vec_2[2];
+        out[2] = vec_1[0] * vec_2[1] - vec_1[1] * vec_2[0];
+        return out;
+    }
+
+    private float dotProduct(float[] vec_1, float[] vec_2) {
+        if (vec_1.length != vec_2.length)
+            throw new ArithmeticException("Vectors do not have the same length");
+
+        float out = 0;
+        for(int i=0; i < vec_1.length; ++i) {
+            out += vec_1[i]*vec_2[i];
+        }
+        return out;
+    }
+
+    private float vectorMagnitude(float[] vec) {
+        return (float)java.lang.Math.sqrt(dotProduct(vec, vec));
+    }
+
+    private float[] normalizeVector(float[] vec) {
+        float magnitude = vectorMagnitude(vec);
+
+        float[] out = new float[vec.length];
+        for (int i=0; i < vec.length; ++i)
+            out[i] = vec[i] / magnitude;
+        return out;
+    }
+
+    private float angleBetweenVecs(float[] vec_1, float[] vec_2) {
+        float numerator = dotProduct(vec_1, vec_2);
+        float denominator = vectorMagnitude(vec_1) * vectorMagnitude(vec_2);
+        return (float)java.lang.Math.acos(numerator/denominator);
+    }
+
+    private float[] axisAngleToMatrix3x3(float angle, float[] axis)
+    {
+        float c = (float)java.lang.Math.cos(angle);
+        float s = (float)java.lang.Math.sin(angle);
+        float x = axis[0];
+        float y = axis[1];
+        float z = axis[2];
+
+        float[] out = new float[9];
+        out[0] = c + x*x*(1 - c);
+        out[1] = x*y*(1 - c) - z*s;
+        out[2] = x*z*(1 - c) + y*s;
+
+        out[3] = x*y*(1 - c) + z*s;
+        out[4] = c + y*y*(1 - c);
+        out[5] = y*z*(1 - c) - x*s;
+
+        out[6] = x*z*(1 - c) - y*s;
+        out[7] = y*z*(1 - c) + x*s;
+        out[8] = c + z*z*(1 - c);
+
+        return out;
+    }
+
+    private float[] innerProductMatrix3x3(float[] mat_1, float[] mat_2) {
+        float[] out = new float[9];
+
+        float[] row_1 = { mat_1[0], mat_1[1], mat_1[2] };
+        float[] row_2 = { mat_1[3], mat_1[4], mat_1[5] };
+        float[] row_3 = { mat_1[6], mat_1[7], mat_1[8] };
+
+        float[] col_1 = { mat_2[0], mat_2[3], mat_2[6] };
+        float[] col_2 = { mat_2[1], mat_2[4], mat_2[7] };
+        float[] col_3 = { mat_2[2], mat_2[5], mat_2[8] };
+
+        out[0] = dotProduct(row_1, col_1);
+        out[1] = dotProduct(row_1, col_2);
+        out[2] = dotProduct(row_1, col_3);
+
+        out[3] = dotProduct(row_2, col_1);
+        out[4] = dotProduct(row_2, col_2);
+        out[5] = dotProduct(row_2, col_3);
+
+        out[6] = dotProduct(row_3, col_1);
+        out[7] = dotProduct(row_3, col_2);
+        out[8] = dotProduct(row_3, col_3);
+
+        return out;
+    }
+
+    // https://blender.stackexchange.com/a/38337
+    float[] vecRollToMatrix3x3(float[] vec, float roll) {
+        float[] target = { 0, 1, 0 };
+        float[] nor = normalizeVector(vec);
+        float[] axis = crossProduct(target, nor);
+
+        float[] bMatrix;
+        if (dotProduct(axis, axis) > 0.0000001) {
+            axis = normalizeVector(axis);
+            float theta = angleBetweenVecs(target, nor);
+            bMatrix = axisAngleToMatrix3x3(theta, axis);
+        }
+        else {
+            float updown = dotProduct(target, nor) > 0 ? 1 : -1;
+            bMatrix = new float[]{
+                    updown,      0,   0,
+                         0, updown,   0,
+                         0,      0,   1
+            };
+        }
+
+        float[] rMatrix = axisAngleToMatrix3x3(roll, nor);
+        return innerProductMatrix3x3(rMatrix, bMatrix);
+    }
+
+    // https://blender.stackexchange.com/a/38337
+    private float[] matrix3x3ToVecRoll(float[] mat) {
+        float[] vec = {mat[1], mat[4], mat[7]};
+        float[] vecmat = vecRollToMatrix3x3(vec, 0);
+
+        // Should invert the matrix here, but since rotation matrices are (should be) orthogonal, can just transpose it
+        float[] vecmatinv = {
+                vecmat[0], vecmat[3], vecmat[6],
+                vecmat[1], vecmat[4], vecmat[7],
+                vecmat[2], vecmat[5], vecmat[8]
+        };
+
+        float[] rollmat = innerProductMatrix3x3(vecmatinv, mat);
+        float roll = (float) java.lang.Math.atan2(rollmat[2], rollmat[8]);
+
+        float[] out = {vec[0], vec[1], vec[2], roll};
+        return out;
+    }
+
+    ////////////////////////////
+    //  END LINALG FUNCTIONS  //
+    ////////////////////////////
+
     public ColldadaExporter(HSMPKCAP hsmp) throws ParserConfigurationException {
         DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
         docFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
@@ -175,27 +377,56 @@ public class ColldadaExporter {
                 elem.setAttribute("name", j.getName());
                 elem.setAttribute("sid", j.getName());
                 elem.setAttribute("type", "JOINT");
-                
-                Element translate = createTextElement("translate", j.getXOffset() + " " + j.getYOffset() + " " + j.getZOffset());
-                
-                double[] angles = j.getAngles();
-                
-                Element rotX = createTextElement("rotate", "1 0 0 " + angles[0]);
-                Element rotY = createTextElement("rotate", "0 1 0 " + angles[1]);
-                Element rotZ = createTextElement("rotate", "0 0 1 " + angles[2]);
-                Element scale = createTextElement("scale", j.getLocalScaleX() + " " + j.getLocalScaleY() + " " + j.getLocalScaleZ());
-                translate.setAttribute("sid", "translate");
-                rotX.setAttribute("sid", "rotateX");
-                rotY.setAttribute("sid", "rotateY");
-                rotZ.setAttribute("sid", "rotateZ");
-                scale.setAttribute("sid", "scale");
-                
-                elem.appendChild(translate);
-                elem.appendChild(rotX);
-                elem.appendChild(rotY);
-                elem.appendChild(rotZ);
-                elem.appendChild(scale);
-                
+
+                float[] pos = {j.getXOffset(), j.getYOffset(), j.getZOffset()};
+                float[] quat = {j.getRotationX(), j.getRotationY(), j.getRotationZ(), j.getRotationW()};
+                float[] scale = {j.getLocalScaleX(), j.getLocalScaleY(), j.getLocalScaleZ()};
+                float[] transform_matrix = makeTransformMatrix(pos, quat, scale);
+                Element matrix = createTextElement(
+                        "matrix",
+                        transform_matrix[ 0] + " " + transform_matrix[ 1] + " " +transform_matrix[ 2] + " " +transform_matrix[ 3] + " " +
+                        transform_matrix[ 4] + " " + transform_matrix[ 5] + " " +transform_matrix[ 6] + " " +transform_matrix[ 7] + " " +
+                        transform_matrix[ 8] + " " + transform_matrix[ 9] + " " +transform_matrix[10] + " " +transform_matrix[11] + " " +
+                        transform_matrix[12] + " " + transform_matrix[13] + " " +transform_matrix[14] + " " +transform_matrix[15]
+                );
+                matrix.setAttribute("sid", "transform");
+                elem.appendChild(matrix);
+
+                float[] vecRoll = matrix3x3ToVecRoll(quaternionToMatrix3x3(quat));
+                float[] tail = {vecRoll[0], vecRoll[1], vecRoll[2]};
+                float roll = vecRoll[3];
+
+                Element extra = doc.createElement("extra");
+                elem.appendChild(extra);
+                Element technique = doc.createElement("technique");
+                technique.setAttribute("profile", "blender");
+                extra.appendChild(technique);
+
+                Element layer = createTextElement("layer", "0");
+                layer.setAttribute("sid", "layer");
+                layer.setAttribute("type", "string");
+                extra.appendChild(layer);
+
+                Element roll_elem = createTextElement("roll", Float.toString(roll));
+                layer.setAttribute("sid", "roll");
+                layer.setAttribute("type", "float");
+                extra.appendChild(roll_elem);
+
+                Element tip_x = createTextElement("tip_x", Float.toString(tail[0]));
+                layer.setAttribute("sid", "tip_x");
+                layer.setAttribute("type", "float");
+                extra.appendChild(tip_x);
+
+                Element tip_y = createTextElement("tip_y", Float.toString(tail[1]));
+                layer.setAttribute("sid", "tip_y");
+                layer.setAttribute("type", "float");
+                extra.appendChild(tip_y);
+
+                Element tip_z = createTextElement("tip_z", Float.toString(tail[2]));
+                layer.setAttribute("sid", "tip_z");
+                layer.setAttribute("type", "float");
+                extra.appendChild(tip_z);
+
                 jointMap.put(i, elem);
                 if(j.getParentId() != -1) 
                     jointMap.get(j.getParentId()).appendChild(elem);
@@ -298,6 +529,7 @@ public class ColldadaExporter {
                     
                     Element skin = doc.createElement("skin");
                     skin.setAttribute("source", "#" + meshName);
+                    skin.appendChild(createTextElement("bind_shape_matrix", "1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1"));
 
                     List<String> names = joints.stream().map(TNOJPayload::getName).collect(Collectors.toList());
                     List<String> bindPose = joints.stream().flatMapToDouble(a -> IntStream.range(0, 16).mapToDouble(b -> a.getOffsetMatrix()[b])).mapToObj(Double::toString).collect(Collectors.toList());

--- a/src/main/java/net/digimonworld/decodetools/gui/util/LinAlg/Matrix.java
+++ b/src/main/java/net/digimonworld/decodetools/gui/util/LinAlg/Matrix.java
@@ -1,0 +1,98 @@
+package net.digimonworld.decodetools.gui.util.LinAlg;
+
+import org.lwjgl.assimp.AIMatrix4x4;
+
+// Would like to use generics so it's easy to e.g. switch to doubles
+public class Matrix {
+    public final int rows;
+    public final int cols;
+    public final float[][] storage;
+
+    //////////////////
+    // CONSTRUCTORS //
+    //////////////////
+    public Matrix(float[][] contents) {
+        this.cols = contents[0].length;
+        for (float[] subarray : contents) {
+            if (subarray.length != this.cols)
+                throw new IllegalArgumentException("Matrix initialized with a ragged list");
+        }
+        this.storage = contents.clone();
+        this.rows = contents.length;
+
+    }
+
+    public Matrix(float[] contents, int rows, int cols) {
+        if (contents.length != rows*cols) {
+            throw new IllegalArgumentException("Matrix initialized with an array inconsistent with the requested rows and columns");
+        }
+
+        this.rows = rows;
+        this.cols = cols;
+        this.storage = new float[rows][cols];
+        for (int i=0; i < rows; ++i)
+            for (int j=0; j < cols; ++j)
+                this.storage[i][j] = contents[i*j + j];
+    }
+
+    public static Matrix fromAIMatrix4x4(AIMatrix4x4 matrix) {
+        float[][] float_matrix = {
+                { matrix.a1(), matrix.a2(), matrix.a3(), matrix.a4()},
+                { matrix.b1(), matrix.b2(), matrix.b3(), matrix.b4()},
+                { matrix.c1(), matrix.c2(), matrix.c3(), matrix.c4()},
+                { matrix.d1(), matrix.d2(), matrix.d3(), matrix.d4()}
+        };
+        return new Matrix(float_matrix);
+    }
+
+
+    //////////////////
+    //   ACCESSORS  //
+    //////////////////
+    public float get(int row, int col) {
+        return storage[row][col];
+    }
+
+    public Vector col(int idx) {
+        float[] column_data = new float[this.rows];
+        for (int i=0; i < this.rows; ++i)
+            column_data[i] = this.storage[i][idx];
+        return new Vector(column_data);
+    }
+
+    public Vector row(int idx) {
+        return new Vector(this.storage[idx]);
+    }
+
+    public float[] toFlatArray() {
+        float[] out = new float[rows*cols];
+        for (int r=0; r < rows; ++r)
+            for (int c=0; c < cols; ++c)
+                out[r*c + c] = storage[r][c];
+        return out;
+    }
+
+    //////////////////
+    //      OPS     //
+    //////////////////
+    public Matrix dot(Matrix other) {
+        if (this.rows != other.cols)
+            throw new IllegalArgumentException("Attempted to dot two incompatible matrices");
+        float[][] result = new float[this.cols][other.rows];
+
+        for (int r=0; r < this.rows; ++r)
+            for (int c=0; c < other.cols; ++c)
+                result[r][c] = this.row(r).dot(other.col(c));
+        return new Matrix(result);
+    }
+
+    public Vector dot(Vector other) {
+        if (this.rows != other.length)
+            throw new IllegalArgumentException("Attempted to dot a matrix with an incompatible vector");
+        float[] result = new float[this.cols];
+
+        for (int r=0; r < this.rows; ++r)
+            result[r] = this.row(r).dot(other);
+        return new Vector(result);
+    }
+}

--- a/src/main/java/net/digimonworld/decodetools/gui/util/LinAlg/Quaternion.java
+++ b/src/main/java/net/digimonworld/decodetools/gui/util/LinAlg/Quaternion.java
@@ -1,0 +1,41 @@
+package net.digimonworld.decodetools.gui.util.LinAlg;
+
+public class Quaternion {
+    public final float[] storage;
+
+    public Quaternion(float x, float y, float z, float w) {
+        this.storage = new float[]{ x, y, z, w };
+    }
+
+    public RotationMatrix toMatrix() {
+        float[][] out = new float[3][3];
+
+        float xSq = 2*storage[0]*storage[0];
+        float ySq = 2*storage[1]*storage[1];
+        float zSq = 2*storage[2]*storage[2];
+
+        float xy = 2*storage[0]*storage[1];
+        float xz = 2*storage[0]*storage[2];
+        float xw = 2*storage[0]*storage[3];
+
+        float yz = 2*storage[1]*storage[2];
+        float yw = 2*storage[1]*storage[3];
+
+        float zw = 2*storage[2]*storage[3];
+
+        // Create rotation matrix
+        out[0][0] = 1 - ySq - zSq;
+        out[0][1] = xy - zw;
+        out[0][2] = xz + yw;
+
+        out[1][0] = xy + zw;
+        out[1][1] = 1 - xSq - zSq;
+        out[1][2] = yz - xw;
+
+        out[2][0] = xz - yw;
+        out[2][1] = yz + xw;
+        out[2][2] = 1 - xSq - ySq;
+
+        return new RotationMatrix(out);
+    }
+}

--- a/src/main/java/net/digimonworld/decodetools/gui/util/LinAlg/RotationMatrix.java
+++ b/src/main/java/net/digimonworld/decodetools/gui/util/LinAlg/RotationMatrix.java
@@ -1,0 +1,93 @@
+package net.digimonworld.decodetools.gui.util.LinAlg;
+
+import java.lang.Math;
+
+public class RotationMatrix extends Matrix {
+    //////////////////
+    // CONSTRUCTORS //
+    //////////////////
+    public RotationMatrix(float[][] contents) {
+        super(contents);
+        if (contents.length != 3 || contents[0].length != 3) // Raggedness will be checked by superclass
+            throw new IllegalArgumentException("Attempted to initialize a RotationMatrix with an incompatible float[][]");
+    }
+
+    public static RotationMatrix fromAxisAngle(Vector3 axis, float angle) {
+        float c = (float)Math.cos(angle);
+        float s = (float)Math.sin(angle);
+        float x = axis.get(0);
+        float y = axis.get(1);
+        float z = axis.get(2);
+
+        float[][] out = new float[3][3];
+        out[0][0] = c + x*x*(1 - c);
+        out[0][1] = x*y*(1 - c) - z*s;
+        out[0][2] = x*z*(1 - c) + y*s;
+
+        out[1][0] = x*y*(1 - c) + z*s;
+        out[1][1] = c + y*y*(1 - c);
+        out[1][2] = y*z*(1 - c) - x*s;
+
+        out[2][0] = x*z*(1 - c) - y*s;
+        out[2][1] = y*z*(1 - c) + x*s;
+        out[2][2] = c + z*z*(1 - c);
+
+        return new RotationMatrix(out);
+    }
+
+    // https://blender.stackexchange.com/a/38337
+    public static RotationMatrix fromVectorRoll(Vector3 vec, float roll) {
+        Vector3 target = new Vector3( 0, 1, 0 );
+        Vector3 nor = Vector3.normalise(target);
+        Vector3 axis = target.cross(nor);
+
+        RotationMatrix bMatrix;
+        if (axis.dot(axis) > 0.0000001) {
+            axis = Vector3.normalise(axis);
+            float theta = target.angleTo(nor);
+            bMatrix = RotationMatrix.fromAxisAngle(axis, theta);
+        }
+        else {
+            float updown = target.dot(nor) > 0 ? 1 : -1;
+            bMatrix = new RotationMatrix(
+                    new float[][]{
+                            {updown,      0,      0},
+                            {     0, updown,      0},
+                            {     0,      0,      1}
+                    }
+            );
+        }
+
+        RotationMatrix rMatrix = RotationMatrix.fromAxisAngle(nor, roll);
+        return rMatrix.dot(bMatrix);
+    }
+
+    public void invert() {
+        float carrier = 0;
+        for (int r=0; r < rows; ++r) {
+            for (int c=0; c < cols; ++c) {
+                carrier = storage[c][r];
+                storage[c][r] = storage[r][c];
+                storage[r][c] = carrier;
+            }
+        }
+    }
+
+    //////////////////
+    //      OPS     //
+    //////////////////
+    public RotationMatrix dot(RotationMatrix other) {
+        return new RotationMatrix(super.dot(other).storage);
+    }
+
+    public float[] toVecRoll() {
+        Vector3 vec = new Vector3(this.col(1)); // Convert to Vec3 to access cross product
+        RotationMatrix vecmat = RotationMatrix.fromVectorRoll(vec, 0);
+        vecmat.invert();
+
+        RotationMatrix rollmat = vecmat.dot(this);
+        float roll = (float) java.lang.Math.atan2(rollmat.get(0, 2), rollmat.get(2, 2));
+
+        return new float[]{vec.get(0), vec.get(1), vec.get(2), roll};
+    }
+}

--- a/src/main/java/net/digimonworld/decodetools/gui/util/LinAlg/TransformMatrix.java
+++ b/src/main/java/net/digimonworld/decodetools/gui/util/LinAlg/TransformMatrix.java
@@ -1,0 +1,46 @@
+package net.digimonworld.decodetools.gui.util.LinAlg;
+
+public class TransformMatrix extends Matrix {
+    public TransformMatrix(float[][] contents) {
+       super(contents);
+       if (contents.length != 4 || contents[0].length != 4) // Raggedness will be checked by superclass
+           throw new IllegalArgumentException("Attempted to initialize a TransformMatrix with an incompatible float[][]");
+    }
+
+    public static TransformMatrix fromTransforms(Vector3 pos, Quaternion quat, Vector3 scale) {
+        RotationMatrix rot_matrix = quat.toMatrix();
+
+        float[][] out = new float[4][4];
+
+        // Inner product of (rotation . scale) - scale is a diagonal matrix
+        // Do it manually to save flops - could do it automatically by subclassing Matrix as DiagonalMatrix and
+        // setting up a bunch of method overloads, but is it worth it for this little code?
+        out[0][0] = rot_matrix.get(0, 0) * scale.get(0);
+        out[1][0] = rot_matrix.get(1, 0) * scale.get(0);
+        out[2][0] = rot_matrix.get(2, 0) * scale.get(0);
+
+        out[0][1] = rot_matrix.get(0, 1) * scale.get(1);
+        out[1][1] = rot_matrix.get(1, 1) * scale.get(1);
+        out[2][1] = rot_matrix.get(2, 1) * scale.get(1);
+
+        out[0][2] = rot_matrix.get(0, 2) * scale.get(2);
+        out[1][2] = rot_matrix.get(1, 2) * scale.get(2);
+        out[2][2] = rot_matrix.get(2, 2) * scale.get(2);
+
+        // Inner product of (translation . rotscale) - translation is a Frobenius matrix
+        out[0][3] = pos.get(0);
+        out[1][3] = pos.get(1);
+        out[2][3] = pos.get(2);
+
+        // Add affine coordinate
+        out[3][0] = 0;
+        out[3][1] = 0;
+        out[3][2] = 0;
+        out[3][3] = 1;
+
+        return new TransformMatrix(out);
+    }
+
+
+
+}

--- a/src/main/java/net/digimonworld/decodetools/gui/util/LinAlg/Vector.java
+++ b/src/main/java/net/digimonworld/decodetools/gui/util/LinAlg/Vector.java
@@ -1,0 +1,53 @@
+package net.digimonworld.decodetools.gui.util.LinAlg;
+
+import java.lang.Math;
+
+public class Vector {
+    public final int length;
+    public final float[] storage;
+
+    //////////////////
+    // CONSTRUCTORS //
+    //////////////////
+    public Vector(float[] contents) {
+        this.storage = contents.clone();
+        this.length = contents.length;
+    }
+
+    public static Vector normalise(Vector v) {
+        float[] contents = v.storage.clone();
+        float magnitude = v.getMagnitude();
+        for (int i=0; i < v.length; ++i)
+            contents[i] /= magnitude;
+        return new Vector(contents);
+    }
+
+    //////////////////
+    //   ACCESSORS  //
+    //////////////////
+    public float get(int idx) {
+        return storage[idx];
+    }
+
+    //////////////////
+    //      OPS     //
+    //////////////////
+    public float dot(Vector other) {
+        float out = 0;
+        if (other.length != this.length)
+            throw new IllegalArgumentException("Attempted to dot two vectors of different lengths");
+        for (int i=0; i < this.length; ++i)
+            out += this.get(i) * other.get(i);
+        return out;
+    }
+
+    public float getMagnitude() {
+        return (float)Math.sqrt(this.dot(this));
+    }
+
+    public float angleTo(Vector other) {
+        float numerator = this.dot(other);
+        float denominator = this.getMagnitude() * other.getMagnitude();
+        return (float)Math.acos(numerator/denominator);
+    }
+}

--- a/src/main/java/net/digimonworld/decodetools/gui/util/LinAlg/Vector3.java
+++ b/src/main/java/net/digimonworld/decodetools/gui/util/LinAlg/Vector3.java
@@ -1,0 +1,31 @@
+package net.digimonworld.decodetools.gui.util.LinAlg;
+
+public class Vector3 extends Vector {
+    //////////////////
+    // CONSTRUCTORS //
+    //////////////////
+    public Vector3(float x, float y, float z) {
+        super(new float[] {x, y, z});
+    }
+
+    public Vector3(Vector v) {
+        super(v.storage);
+        if (v.length != 3)
+            throw new IllegalArgumentException("Attempted to initialize a Vector3 with a vector that did not have a length of 3");
+    }
+
+    public static Vector3 normalise(Vector3 v) {
+        return new Vector3(Vector.normalise(v));
+    }
+
+    //////////////////
+    //      OPS     //
+    //////////////////
+    public Vector3 cross(Vector3 other) {
+        float[] out = new float[3];
+        float x = this.get(1) * other.get(2) - this.get(2) * other.get(1);
+        float y = this.get(2) * other.get(0) - this.get(0) * other.get(2);
+        float z = this.get(0) * other.get(1) - this.get(1) * other.get(0);
+        return new Vector3(x, y, z);
+    }
+}

--- a/src/main/java/net/digimonworld/decodetools/res/payload/TNOJPayload.java
+++ b/src/main/java/net/digimonworld/decodetools/res/payload/TNOJPayload.java
@@ -41,7 +41,7 @@ public class TNOJPayload extends NameablePayload {
     private float localScaleZ; // ?
     // padding
     
-    public TNOJPayload(AbstractKCAP parent, int parentBone, String name, int unknown1, int unknown2, float[] parentMatrix, 
+    public TNOJPayload(AbstractKCAP parent, int parentBone, String name, int unknown1, int unknown2, float[] inverse_bind_pose_matrix,
                        float[] offsetVector, float[] unknownVector, float[] scaleVector, float[] localScaleVector) {
         super(parent, name);
         
@@ -49,7 +49,7 @@ public class TNOJPayload extends NameablePayload {
         this.unknown1 = unknown1;
         this.unknown2 = unknown2;
         
-        this.matrix = Arrays.copyOf(parentMatrix, 16);
+        this.matrix = Arrays.copyOf(inverse_bind_pose_matrix, 16);
         
         this.xOffset = offsetVector[0];
         this.yOffset = offsetVector[1];
@@ -68,12 +68,6 @@ public class TNOJPayload extends NameablePayload {
         this.localScaleX = localScaleVector[0];
         this.localScaleY = localScaleVector[1];
         this.localScaleZ = localScaleVector[2];
-        
-        matrix[3] -= xOffset;
-        matrix[7] -= yOffset;
-        matrix[11] -= zOffset;
-        
-        // TODO proper modification of the matrix, taking into account scale and rotation
     }
     
     public TNOJPayload(Access source, int dataStart, AbstractKCAP parent, int size, String name) {


### PR DESCRIPTION
- Now imports full inverse bind pose matrices from assimp, rather than just the bone translations
- Now imports quats and scales for bone rest pose, rather than just the bone translations
- Change COLLADA node export to use <matrix> rather than <translation><rotate><scale>, since Blender can pick it up
- Add <extra> tag to COLLADA nodes so that Blender will properly import bone rotations